### PR TITLE
Fixed: PR check failing on slack message

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
           path: ./allure-results
 
       - name: Send Slack Message
+        if: ${{ github.event_name == 'push' }}
         # Will contain Allure Reports URL in the data block
         run: >
           curl -X POST -H 'Content-type: application/json' 


### PR DESCRIPTION
PR checks were failing on `Send Slack Message` step, thus made it to run only on push events. 